### PR TITLE
Fix for ISR not in RAM!

### DIFF
--- a/RBDdimmerESP8266/src/RBDdimmerESP8266.cpp
+++ b/RBDdimmerESP8266/src/RBDdimmerESP8266.cpp
@@ -88,9 +88,7 @@ void dimmerLampESP8266::setPower(int power)
 
 int dimmerLampESP8266::getPower(void)
 {
-	if (dimState[this->current_num] == ON)
-		return dimPower[this->current_num];
-	else return 0;
+	return dimPower[this->current_num] ? dimPower[this->current_num] : 0;
 }
 
 void dimmerLampESP8266::setState(ON_OFF_typedef ON_OFF)

--- a/RBDdimmerESP8266/src/RBDdimmerESP8266.h
+++ b/RBDdimmerESP8266/src/RBDdimmerESP8266.h
@@ -32,8 +32,8 @@ static const uint8_t powerBuf[] = {
 
 #define ALL_DIMMERS 100
 
-void handleInterrupt(void);
-void ICACHE_RAM_ATTR onTimerISR();
+ICACHE_RAM_ATTR void handleInterrupt(void);
+ICACHE_RAM_ATTR void onTimerISR();
 
 class dimmerLampESP8266 
 {         


### PR DESCRIPTION
Library crashes with ISR not in RAM! Wen using ESP8266 core for Arduino version 3.0.0 and above. At least in my case I started with 3.0.0 and app crashed. The following patch resolved the issue.